### PR TITLE
Add arguments documentation for provider

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -15,4 +15,9 @@ provider "awx" {
 
 ## Argument Reference
 
-* List any arguments for the provider **block.**
+The following arguments are supported:
+
+* `hostname` - (Optional) The API endpoint for AWX. Defaults to `"http://localhost"`.
+* `username` - (Optional) The username for API access. Defaults to `"admin"`.
+* `password` - (Optional) The password for API access. Defaults to `"password"`.
+* `insecure` - (Optional) Whether to check the TLS certificate. Defaults to `false`.


### PR DESCRIPTION
Explicit the arguments list. Mostly to document the 'insecure' argument.