### PR TITLE
Fix inventory_source

### DIFF
--- a/awx/resource_inventory_source.go
+++ b/awx/resource_inventory_source.go
@@ -105,6 +105,14 @@ func resourceInventorySource() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"source_project_id": {
+				Type:     schema.TypeInt,
+				Optional: true,
+			},
+			"source_path": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 		},
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
@@ -136,8 +144,8 @@ func resourceInventorySourceCreate(ctx context.Context, d *schema.ResourceData, 
 		"source_regions":   d.Get("source_regions").(string),
 		"instance_filters": d.Get("instance_filters").(string),
 		"group_by":         d.Get("group_by").(string),
-		// "source_project":   d.Get("source_project_id").(int),
-		// "source_path":      d.Get("source_path").(string),
+		"source_project":   d.Get("source_project_id").(int),
+		"source_path":      d.Get("source_path").(string),
 	}, map[string]string{})
 	if err != nil {
 		return buildDiagCreateFail(diagElementInventorySourceTitle, err)
@@ -176,8 +184,8 @@ func resourceInventorySourceUpdate(ctx context.Context, d *schema.ResourceData, 
 		"source_regions":   d.Get("source_regions").(string),
 		"instance_filters": d.Get("instance_filters").(string),
 		"group_by":         d.Get("group_by").(string),
-		// "source_project":   d.Get("source_project_id").(int),
-		// "source_path":      d.Get("source_path").(string),
+		"source_project":   d.Get("source_project_id").(int),
+		"source_path":      d.Get("source_path").(string),
 	}, nil)
 	if err != nil {
 		return buildDiagUpdateFail(diagElementInventorySourceTitle, id, err)
@@ -238,8 +246,8 @@ func setInventorySourceResourceData(d *schema.ResourceData, r *awx.InventorySour
 	d.Set("source_regions", r.SourceRegions)
 	d.Set("instance_filters", r.InstanceFilters)
 	d.Set("group_by", r.GroupBy)
-	// d.Set("source_project_id", r.SourceProject)
-	// d.Set("source_path", r.SourcePath)
+	d.Set("source_project_id", r.SourceProject)
+	d.Set("source_path", r.SourcePath)
 
 	return d
 }


### PR DESCRIPTION
Adds the possibility to use source_id inside resource_inventory_source.
This is particular important because it's the only way to enable dynamic inventory.

The corresponding issue is:
https://github.com/denouche/terraform-provider-awx/issues/17