### PR TITLE
fix: segmentation fault when datasource does not exist

### DIFF
--- a/awx/data_source_execution_environment.go
+++ b/awx/data_source_execution_environment.go
@@ -56,7 +56,6 @@ func dataSourceExecutionEnvironmentsRead(ctx context.Context, d *schema.Resource
 			"Get: Missing Parameters",
 			"Please use one of the selectors (name or group_id)",
 		)
-		return diags
 	}
 	executionEnvironments, _, err := client.ExecutionEnvironmentsService.ListExecutionEnvironments(params)
 	if err != nil {
@@ -72,7 +71,13 @@ func dataSourceExecutionEnvironmentsRead(ctx context.Context, d *schema.Resource
 			"The query returns more than one execution environment, %d",
 			len(executionEnvironments),
 		)
-		return diags
+	}
+	if len(executionEnvironments) == 0 {
+		return buildDiagnosticsMessage(
+			"Get: Execution Environment does not exist",
+			"The Query Returns no Execution Environment matching filter %v",
+			params,
+		)
 	}
 
 	executionEnvironment := executionEnvironments[0]

--- a/awx/data_source_inventory.go
+++ b/awx/data_source_inventory.go
@@ -63,25 +63,31 @@ func dataSourceInventoriesRead(ctx context.Context, d *schema.ResourceData, m in
 	if len(params) == 0 {
 		return buildDiagnosticsMessage(
 			"Get: Missing Parameters",
-			"Please use one of the selectors (name or group_id)",
+			"Please use one of the selectors (name or id)",
 		)
-		return diags
 	}
 	inventories, _, err := client.InventoriesService.ListInventories(params)
 	if err != nil {
 		return buildDiagnosticsMessage(
-			"Get: Fail to fetch Inventory Group",
-			"Fail to find the group got: %s",
+			"Get: Fail to fetch Inventory",
+			"Fail to find the inventory got: %s",
 			err.Error(),
 		)
 	}
 	if len(inventories) > 1 {
 		return buildDiagnosticsMessage(
 			"Get: find more than one Element",
-			"The Query Returns more than one Group, %d",
+			"The Query Returns more than one Inventory, %d",
 			len(inventories),
 		)
-		return diags
+	}
+
+	if len(inventories) == 0 {
+		return buildDiagnosticsMessage(
+			"Get: Inventory does not exist",
+			"The Query Returns no Inventory matching filter %v",
+			params,
+		)
 	}
 
 	inventory := inventories[0]

--- a/awx/data_source_inventory_group.go
+++ b/awx/data_source_inventory_group.go
@@ -59,9 +59,8 @@ func dataSourceInventoryGroupRead(ctx context.Context, d *schema.ResourceData, m
 	if len(params) == 0 {
 		return buildDiagnosticsMessage(
 			"Get: Missing Parameters",
-			"Please use one of the selectors (name or group_id)",
+			"Please use one of the selectors (name or id)",
 		)
-		return diags
 	}
 	inventoryID := d.Get("inventory_id").(int)
 	groups, _, err := client.InventoryGroupService.ListInventoryGroups(inventoryID, params)
@@ -75,10 +74,16 @@ func dataSourceInventoryGroupRead(ctx context.Context, d *schema.ResourceData, m
 	if len(groups) > 1 {
 		return buildDiagnosticsMessage(
 			"Get: find more than one Element",
-			"The Query Returns more than one Group, %d",
+			"The Query Returns more than one Inventory Group, %d",
 			len(groups),
 		)
-		return diags
+	}
+	if len(groups) == 0 {
+		return buildDiagnosticsMessage(
+			"Get: Inventory Group does not exist",
+			"The Query Returns no Inventory Group matching filter %v",
+			params,
+		)
 	}
 
 	group := groups[0]

--- a/awx/data_source_job_template.go
+++ b/awx/data_source_job_template.go
@@ -80,11 +80,18 @@ func dataSourceJobTemplateRead(ctx context.Context, d *schema.ResourceData, m in
 
 	if _, okGroupID := d.GetOk("id"); okGroupID {
 		log.Printf("byid %v", len(jobTemplate))
-		if len(jobTemplate) != 1 {
+		if len(jobTemplate) > 1 {
 			return buildDiagnosticsMessage(
 				"Get: find more than one Element",
 				"The Query Returns more than one Group, %d",
 				len(jobTemplate),
+			)
+		}
+		if len(jobTemplate) == 0 {
+			return buildDiagnosticsMessage(
+				"Get: Job Template does not exist",
+				"The Query Returns no Job Template matching filter %v",
+				params,
 			)
 		}
 		d = setJobTemplateResourceData(d, jobTemplate[0])

--- a/awx/data_source_notification_template.go
+++ b/awx/data_source_notification_template.go
@@ -73,6 +73,13 @@ func dataSourceNotificationTemplatesRead(ctx context.Context, d *schema.Resource
 			len(notificationTemplates),
 		)
 	}
+	if len(notificationTemplates) == 0 {
+		return buildDiagnosticsMessage(
+			"Get: Notification Template does not exist",
+			"The Query Returns no Notification Template matching filter %v",
+			params,
+		)
+	}
 
 	notificationTemplate := notificationTemplates[0]
 	d = setNotificationTemplateResourceData(d, notificationTemplate)

--- a/awx/data_source_organization.go
+++ b/awx/data_source_organization.go
@@ -56,7 +56,6 @@ func dataSourceOrganizationRead(ctx context.Context, d *schema.ResourceData, m i
 			"Get: Missing Parameters",
 			"Please use one of the selectors (name or group_id)",
 		)
-		return diags
 	}
 	organizations, err := client.OrganizationsService.ListOrganizations(params)
 	if err != nil {
@@ -72,7 +71,13 @@ func dataSourceOrganizationRead(ctx context.Context, d *schema.ResourceData, m i
 			"The Query Returns more than one organization, %d",
 			len(organizations),
 		)
-		return diags
+	}
+	if len(organizations) == 0 {
+		return buildDiagnosticsMessage(
+			"Get: Organization does not exist",
+			"The Query Returns no Organization matching filter %v",
+			params,
+		)
 	}
 
 	organization := organizations[0]

--- a/awx/data_source_project.go
+++ b/awx/data_source_project.go
@@ -57,7 +57,7 @@ func dataSourceProjectsRead(ctx context.Context, d *schema.ResourceData, m inter
 			"Please use one of the selectors (name or group_id)",
 		)
 	}
-	Projects, _, err := client.ProjectService.ListProjects(params)
+	projects, _, err := client.ProjectService.ListProjects(params)
 	if err != nil {
 		return buildDiagnosticsMessage(
 			"Get: Fail to fetch Inventory Group",
@@ -65,15 +65,22 @@ func dataSourceProjectsRead(ctx context.Context, d *schema.ResourceData, m inter
 			err.Error(),
 		)
 	}
-	if len(Projects) > 1 {
+	if len(projects) > 1 {
 		return buildDiagnosticsMessage(
 			"Get: find more than one Element",
 			"The Query Returns more than one Group, %d",
-			len(Projects),
+			len(projects),
+		)
+	}
+	if len(projects) == 0 {
+		return buildDiagnosticsMessage(
+			"Get: Project does not exist",
+			"The Query Returns no Project matching filter %v",
+			params,
 		)
 	}
 
-	Project := Projects[0]
-	d = setProjectResourceData(d, Project)
+	project := projects[0]
+	d = setProjectResourceData(d, project)
 	return diags
 }

--- a/awx/data_source_schedule.go
+++ b/awx/data_source_schedule.go
@@ -73,6 +73,13 @@ func dataSourceSchedulesRead(ctx context.Context, d *schema.ResourceData, m inte
 			len(schedules),
 		)
 	}
+	if len(schedules) == 0 {
+		return buildDiagnosticsMessage(
+			"Get: Schedule does not exist",
+			"The Query Returns no Schedule matching filter %v",
+			params,
+		)
+	}
 
 	schedule := schedules[0]
 	d = setScheduleResourceData(d, schedule)

--- a/awx/data_source_team.go
+++ b/awx/data_source_team.go
@@ -65,11 +65,20 @@ func dataSourceTeamsRead(ctx context.Context, d *schema.ResourceData, m interfac
 			err.Error(),
 		)
 	}
+
 	if len(Teams) > 1 {
 		return buildDiagnosticsMessage(
 			"Get: find more than one Element",
 			"The Query Returns more than one team, %d",
 			len(Teams),
+		)
+	}
+
+	if len(Teams) == 0 {
+		return buildDiagnosticsMessage(
+			"Get: Team does not exist",
+			"The Query Returns no Team matching filter %v",
+			params,
 		)
 	}
 

--- a/awx/data_source_workflow_job_template.go
+++ b/awx/data_source_workflow_job_template.go
@@ -74,11 +74,18 @@ func dataSourceWorkflowJobTemplateRead(ctx context.Context, d *schema.ResourceDa
 		}
 	}
 	if _, okGroupID := d.GetOk("id"); okGroupID {
-		if len(workflowJobTemplate) != 1 {
+		if len(workflowJobTemplate) > 1 {
 			return buildDiagnosticsMessage(
 				"Get: find more than one Element",
 				"The Query Returns more than one Group, %d",
 				len(workflowJobTemplate),
+			)
+		}
+		if len(workflowJobTemplate) == 0 {
+			return buildDiagnosticsMessage(
+				"Get: Workflow template does not exist",
+				"The Query Returns no Workflow template matching filter %v",
+				params,
 			)
 		}
 		d = setWorkflowJobTemplateResourceData(d, workflowJobTemplate[0])


### PR DESCRIPTION
Most data sources trigger a segfault when the ID or name cannot be found.
I added a dedicated check and error message to make sure only one item exists