### PR TITLE
Fix schedule replacing

### DIFF
--- a/awx/resource_schedule.go
+++ b/awx/resource_schedule.go
@@ -47,6 +47,7 @@ func resourceSchedule() *schema.Resource {
 			"unified_job_template_id": {
 				Type:     schema.TypeInt,
 				Required: true,
+				ForceNew: true,
 			},
 			"description": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
Without `ForceNew` resource does not reassign to new template when `unified_job_template_id` was changed.