### PR TITLE
fix(resource_organization): Plugin crashes when creating an awx organization that already exists

### DIFF
--- a/awx/resource_organization.go
+++ b/awx/resource_organization.go
@@ -1,14 +1,15 @@
 /*
 *TBD*
 
-Example Usage
+# Example Usage
 
 ```hcl
-resource "awx_organization" "default" {
-  name            = "acc-test"
-}
-```
 
+	resource "awx_organization" "default" {
+	  name            = "acc-test"
+	}
+
+```
 */
 package awx
 
@@ -87,8 +88,8 @@ func resourceOrganizationsCreate(ctx context.Context, d *schema.ResourceData, m 
 		log.Printf("Fail to Create Organization %v", err)
 		diags = append(diags, diag.Diagnostic{
 			Severity: diag.Error,
-			Summary:  "Unable to create Organizations",
-			Detail:   fmt.Sprintf("Organizations with name %s in the project id %d, failed to create %s", d.Get("name").(string), d.Get("project_id").(int), err.Error()),
+			Summary:  "Unable to create organization",
+			Detail:   fmt.Sprintf("Failed to create organization with name %s, got %s", d.Get("name").(string), err.Error()),
 		})
 		return diags
 	}


### PR DESCRIPTION
# PR to fix issue #66 

## Bug description

When trying to create an AWX organization with a name that already exists, the plugin crashes as it is trying to parse a variable `project_id` which doesn't exists:

```
awx_organization.test2: Creating...
╷
│ Error: Request cancelled
│ 
│   with awx_organization.test2,
│   on test-org-bug.tf line 7, in resource "awx_organization" "test2":
│    7: resource "awx_organization" "test2" {
│ 
│ The plugin.(*GRPCProvider).ApplyResourceChange request was cancelled.
╵

Stack trace from the terraform-provider-awx plugin:

panic: interface conversion: interface {} is nil, not int

goroutine 27 [running]:
github.com/denouche/terraform-provider-awx/awx.resourceOrganizationsCreate({0xe07900, 0xc0001ec930}, 0x0?, {0xb8edc0?, 0xc0001d4700?})
        /home/maxwoerner/dev/terraform-provider-awx-maxwoerner/awx/resource_organization.go:91 +0x74a
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0xc0000eba40, {0xe07858, 0xc000682210}, 0xd?, {0xb8edc0, 0xc0001d4700})
        /home/maxwoerner/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.30.0/helper/schema/resource.go:778 +0x11b
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc0000eba40, {0xe07858, 0xc000682210}, 0xc00078e1a0, 0xc00041a180, {0xb8edc0, 0xc0001d4700})
        /home/maxwoerner/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.30.0/helper/schema/resource.go:909 +0xa89
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc000399c38, {0xe07858?, 0xc000682120?}, 0xc000692000)
        /home/maxwoerner/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.30.0/helper/schema/grpc_provider.go:1072 +0xdbc
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc000256f00, {0xe07858?, 0xc000211d70?}, 0xc0001ed260)
        /home/maxwoerner/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.19.0/tfprotov5/tf5server/server.go:859 +0x56b
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0xcaae00?, 0xc000256f00}, {0xe07858, 0xc000211d70}, 0xc0001ed1f0, 0x0)
        /home/maxwoerner/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.19.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:467 +0x169
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00024a1e0, {0xe0b960, 0xc0003cc4e0}, 0xc0003da000, 0xc0003a39e0, 0x132e2b8, 0x0)
        /home/maxwoerner/go/pkg/mod/google.golang.org/grpc@v1.57.1/server.go:1358 +0xe15
google.golang.org/grpc.(*Server).handleStream(0xc00024a1e0, {0xe0b960, 0xc0003cc4e0}, 0xc0003da000, 0x0)
        /home/maxwoerner/go/pkg/mod/google.golang.org/grpc@v1.57.1/server.go:1735 +0x9e7
google.golang.org/grpc.(*Server).serveStreams.func1.1()
        /home/maxwoerner/go/pkg/mod/google.golang.org/grpc@v1.57.1/server.go:970 +0xbb
created by google.golang.org/grpc.(*Server).serveStreams.func1 in goroutine 13
        /home/maxwoerner/go/pkg/mod/google.golang.org/grpc@v1.57.1/server.go:981 +0x145

Error: The terraform-provider-awx plugin crashed!

This is always indicative of a bug within the plugin. It would be immensely
helpful if you could report the crash with the plugin's maintainers so that it
can be fixed. The output above should help diagnose the issue.
```

## Solution

Removing the variable `project_id` from the error message fixes the problem and provides the correct error message to the user:

```
awx_organization.test2: Creating...
╷
│ Error: Unable to create organization
│ 
│   with awx_organization.test2,
│   on test-org-bug.tf line 7, in resource "awx_organization" "test2":
│    7: resource "awx_organization" "test2" {
│ 
│ Failed to create organization with name test-org-12345, got Errors:
│ - name: [Organization with this Name already exists.]
```
