### PR TITLE
Add Timeout to Job Launch

### DIFF
--- a/awx/resource_job_template_launch.go
+++ b/awx/resource_job_template_launch.go
@@ -85,6 +85,9 @@ func resourceJobTemplateLaunch() *schema.Resource {
 				ForceNew:    true,
 			},
 		},
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(20 * time.Minute),
+		},
 	}
 }
 


### PR DESCRIPTION
This adds the ability to define the timeout for Terraform to wait for an AWX job launch to complete. This is good for especially long job runs.

Usage example:

```terraform
resource "awx_job_template_launch" "now" {
  job_template_id     = awx_job_template.cool_job.id
  wait_for_completion = true
  extra_vars          = jsonencode({})

  timeouts {
    create = "60m"
  }
}
```