### PR TITLE
Add functionality to import job and workflow job templates

### DIFF
--- a/awx/resource_job_template.go
+++ b/awx/resource_job_template.go
@@ -202,6 +202,9 @@ func resourceJobTemplate() *schema.Resource {
 				Default:  "",
 			},
 		},
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
 	}
 }
 

--- a/awx/resource_workflow_job_template.go
+++ b/awx/resource_workflow_job_template.go
@@ -1,16 +1,17 @@
 /*
 *TBD*
 
-Example Usage
+# Example Usage
 
 ```hcl
-resource "awx_workflow_job_template" "default" {
-  name            = "workflow-job"
-  organization_id = var.organization_id
-  inventory_id    = awx_inventory.default.id
-}
-```
 
+	resource "awx_workflow_job_template" "default" {
+	  name            = "workflow-job"
+	  organization_id = var.organization_id
+	  inventory_id    = awx_inventory.default.id
+	}
+
+```
 */
 package awx
 
@@ -113,6 +114,9 @@ func resourceWorkflowJobTemplate() *schema.Resource {
 				Optional: true,
 				Default:  "",
 			},
+		},
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
 		},
 	}
 }

--- a/awx/resource_workflow_job_template.go
+++ b/awx/resource_workflow_job_template.go
@@ -1,17 +1,16 @@
 /*
 *TBD*
 
-# Example Usage
+Example Usage
 
 ```hcl
-
-	resource "awx_workflow_job_template" "default" {
-	  name            = "workflow-job"
-	  organization_id = var.organization_id
-	  inventory_id    = awx_inventory.default.id
-	}
-
+resource "awx_workflow_job_template" "default" {
+  name            = "workflow-job"
+  organization_id = var.organization_id
+  inventory_id    = awx_inventory.default.id
+}
 ```
+
 */
 package awx
 


### PR DESCRIPTION
After this change it is possible to import existing resources with Terraform [import blocks](https://developer.hashicorp.com/terraform/language/import). 

For example:

```
import {
  id = "42"
  to = module.this.awx_workflow_job_template.foo
}
```

